### PR TITLE
fixed: 刷卡時因 timezone 不合而產生「系統時間不正確」錯誤

### DIFF
--- a/2017/Dockerfile
+++ b/2017/Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get install --no-install-recommends -y firefox ttf-wqy-microhei  default
 RUN apt-get install -y locales \
  && locale-gen zh_TW zh_TW.UTF-8 zh_CN zh_CN.UTF-8 en
 
+# Setup timezone
+RUN apt-get install -y tzdata \
+ && ln -fs /usr/share/zoneinfo/Asia/Taipei /etc/localtime
+
 RUN apt-get install --no-install-recommends -y pcscd pcsc-tools
 # setup sudo for pcscd
 RUN apt-get install -y sudo \


### PR DESCRIPTION
Before: 進入信用卡繳費畫面時，會跳出「時間不正確，請調整系統時間」相關警告，並且無法送出信用卡資訊。
Now: Works with no warning.